### PR TITLE
Update yunmai-new-token.js

### DIFF
--- a/yunmai-new-token.js
+++ b/yunmai-new-token.js
@@ -26,7 +26,7 @@ console.log("If you get more than one set of settings for conf.toml, always use 
 adb = spawn('C:\\Program Files (x86)\\Android\\android-sdk\\platform-tools\\adb.exe', ['logcat']);
 
 adb.stdout.on('data', function (data) {
-  const regex = /http:\/\/int\.api\.iyunmai\.com\/api\/android\/scale\/[0-9]+\/list\.json\?code=[0-9]+&%26startTime=[0-9]+&lang=2&userId=[0-9]+&token=[0-9a-fA-F]+/mi;
+  const regex = /http:\/\/intapi\.iyunmai\.com\/api\/android\/scale\/[0-9]+\/chart-list\.json\?code=[0-9]+&startTime=[0-9]+&lang=2&userId=[0-9]+&token=[0-9a-fA-F]+/mi;
 
   let m;
 


### PR DESCRIPTION
URL change in recent version of app (2.1.8.1 on my device). The old URL construct no longer works that I can see, updating yunmai-new-token.js with my change on line 29 to the new URL construct solves the issue.

Specifically, when running node yunmai-new-token.js with the int.api.yunmai.com/api/android/scale/[0-9]+/list.json URL in the const regex no longer shows any data. A tcpdump on the device shows that it's actually now connecting to http://intapi.iyunmai.com/api/android/scale/[0-9]+/chart-list.json so updated yunmai-new-token.js and re-ran with node and saw expected code, scale, user and token output.